### PR TITLE
Recreate list of edge colors after NetworkX shuffles them

### DIFF
--- a/grn.py
+++ b/grn.py
@@ -150,10 +150,21 @@ class grn:
         edges_inh -= edges_both
 
         edges = list(edges_both) + list(edges_act) + list(edges_inh)
-        colors = ['orange']*len(edges_both) + ['blue']*len(edges_act) + ['red']*len(edges_inh)
+        # colors = ['orange']*len(edges_both) + ['blue']*len(edges_act) + ['red']*len(edges_inh)
 
         G = nx.DiGraph()
         G.add_edges_from(edges)
+
+        edges = list(G.edges)
+        colors = []
+        for edge in edges:
+            if edge in edges_both:
+                colors.append('orange')
+            elif edge in edges_act:
+                colors.append('blue')
+            elif edge in edges_inh:
+                colors.append('red')
+
         nx.draw_networkx(G, pos=nx.circular_layout(G), arrows=True, node_color = 'w', edge_color=colors)
         plt.show()
 


### PR DESCRIPTION
nx.DiGraph.add_edges_from doesn't guarantee that its internal list of edges will have the same ordering as the list that is passed to it.
So the list of edge colors no longer corresponds the list of edges passed to it unless we recreate it.